### PR TITLE
fix/get-practice-attribtue-from-round

### DIFF
--- a/client/game/ContentRight/LocalBars.jsx
+++ b/client/game/ContentRight/LocalBars.jsx
@@ -76,11 +76,10 @@ export default class LocalBars extends React.Component {
   };
 
   render() {
-    const { round, stage } = this.props;
-    const stageType = stage.get("practice") ? "practice" : "exp";
-    let currentModel = modelLocalJson.filter((m) => m.type === stageType);
-    currentModel = stageType === "practice" ? currentModel[0] : currentModel[round.index - 1];
-
+    const { round } = this.props;
+    const roundType = round.get("practice") ? "practice" : "exp";
+    let currentModel = modelLocalJson.filter((m) => m.type === roundType);
+    currentModel = roundType === "practice" ? currentModel[0] : currentModel[round.index - 1];
     return (
       <div className="graph-wrapper">
         <div className="graph">


### PR DESCRIPTION
### FIX

In this current fix, i used `practice` attribute from `round.get("practice")`, not from the `stage`. I saw there is inconsistent assignment on practice attribute inside stage.