### PR TITLE
fix: hide scroll on initial render

### DIFF
--- a/client/game/SocialExposure.jsx
+++ b/client/game/SocialExposure.jsx
@@ -30,9 +30,6 @@ export default class SocialExposure extends React.Component {
   renderSlider() {
     const { player, round, stage } = this.props;
     let prediction = player.round.get("prediction");
-    if (prediction === null || prediction === undefined) {
-      prediction = 0.5;
-    }
     const predictionProb =
       round.get("model_prediction_prob") ||
       round.get("task").model_prediction_prob;
@@ -46,8 +43,6 @@ export default class SocialExposure extends React.Component {
       stage.name === "outcome" || stage.name === "practice-outcome";
     stage.name === "outcome" || stage.name === "practice-outcome";
     const aiPrediction = (!isSolo && predictionProb) || null;
-    // const userPrediction = (isSocial && initialPrediction) || null;
-    // const userFinalPrediction = (isOutcome && prediction) || null;
 
     const userPrediction =
       isSocial && initialPrediction !== null && initialPrediction !== undefined

--- a/client/game/TaskResponse.jsx
+++ b/client/game/TaskResponse.jsx
@@ -60,9 +60,10 @@ export default class TaskResponse extends React.Component {
   renderSlider(disabled) {
     const { player, round, stage } = this.props;
     let prediction = player.round.get("prediction");
-    if (prediction === null || prediction === undefined) {
-      prediction = 0.5;
-    }
+    // if (prediction === null || prediction === undefined) {
+    //   prediction = 0.5;
+    // }
+
     const predictionProb =
       round.get("model_prediction_prob") ||
       round.get("task").model_prediction_prob;

--- a/client/game/component/Slider.jsx
+++ b/client/game/component/Slider.jsx
@@ -57,6 +57,7 @@ export default ({
           labelRenderer={(number) => {
             return number.toFixed(2).toString();
           }}
+          hideHandleOnEmpty
         />
         {aiPrediction !== null && aiPrediction !== undefined && (
           <div
@@ -122,7 +123,7 @@ export default ({
             </div>
           </div>
         )}
-        {newPrediction && (
+        {newPrediction && value !== null && value !== undefined && (
           <div
             className="prediction new-prediction"
             style={{ left: `calc(${newPredictPercentage}% - 6.5px)` }}


### PR DESCRIPTION
This PR contain changes for scroll hide on empty. Also, alignment for behaviour final prediction and new prediction if user leave empty their prediction (when timed out). 